### PR TITLE
Validators

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 codemix ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ foreach($db->classes as $name => $class) {
   echo $name."\n";
 }
 ```
+
+
+# License
+
+MIT, see [LICENSE.md](./LICENSE.md).

--- a/src/Orienta/Classes/ClassInterface.php
+++ b/src/Orienta/Classes/ClassInterface.php
@@ -3,6 +3,7 @@
 namespace Orienta\Classes;
 
 use Orienta\Databases\Database;
+use Orienta\Validation\ValidatorInterface;
 
 /**
  *
@@ -15,7 +16,7 @@ use Orienta\Databases\Database;
  * @property PropertyList $properties
  *
  */
-interface ClassInterface
+interface ClassInterface extends ValidatorInterface
 {
     /**
      * Sets the Database

--- a/src/Orienta/Classes/ClassTrait.php
+++ b/src/Orienta/Classes/ClassTrait.php
@@ -136,6 +136,27 @@ trait ClassTrait
 
 
     /**
+     * Validate the given value.
+     *
+     * @param mixed $value The value to validate.
+     *
+     * @return array An array containing a boolean which is true if the value is valid,
+     *                followed by an array of validation errors, if any.
+     */
+    public function validate($value)
+    {
+        $allErrors = [];
+        foreach($this->getProperties() as $name => $property /* @var Property $property */) {
+            list($isValid, $errors) = $property->validate(isset($value[$name]) ? $value[$name] : null);
+            if (!$isValid) {
+                $allErrors = array_merge($allErrors, $errors);
+            }
+        }
+        return [count($allErrors) === 0, $allErrors];
+    }
+
+
+    /**
      * Get an attribute with the given name.
      *
      * @param string $name The name of the attribute to get.

--- a/src/Orienta/Classes/Property.php
+++ b/src/Orienta/Classes/Property.php
@@ -2,7 +2,14 @@
 
 namespace Orienta\Classes;
 
-class Property implements PropertyInterface
+use Orienta\Common\ConfigurableInterface;
+use Orienta\Common\ConfigurableTrait;
+use Orienta\Common\MagicInterface;
+use Orienta\Common\MagicTrait;
+
+class Property implements PropertyInterface, ConfigurableInterface, MagicInterface
 {
     use PropertyTrait;
+    use MagicTrait;
+    use ConfigurableTrait;
 }

--- a/src/Orienta/Classes/Property.php
+++ b/src/Orienta/Classes/Property.php
@@ -6,10 +6,23 @@ use Orienta\Common\ConfigurableInterface;
 use Orienta\Common\ConfigurableTrait;
 use Orienta\Common\MagicInterface;
 use Orienta\Common\MagicTrait;
+use Orienta\Validation\ValidatorInterface;
 
-class Property implements PropertyInterface, ConfigurableInterface, MagicInterface
+class Property implements PropertyInterface, ConfigurableInterface, MagicInterface, ValidatorInterface
 {
     use PropertyTrait;
     use MagicTrait;
     use ConfigurableTrait;
+
+    /**
+     * @param ClassInterface $class The class for the property.
+     * @param array $config The configuration for the property.
+     */
+    public function __construct(ClassInterface $class = null, array $config = null)
+    {
+        $this->class = $class;
+        if ($config !== null) {
+            $this->configure($config);
+        }
+    }
 }

--- a/src/Orienta/Classes/PropertyInterface.php
+++ b/src/Orienta/Classes/PropertyInterface.php
@@ -13,6 +13,8 @@ namespace Orienta\Classes;
  * @property int|null $min The minimum value, if any.
  * @property int|null $max The maximum value, if any.
  * @property string $regexp The regular expression for this property.
+ * @property string $collate The collation for this property.
+ * @property string $linkedClass The linked class for this property.
  * @property array $customFields The custom fields for the property.
  *
  * @package Orienta\Classes

--- a/src/Orienta/Classes/PropertyList.php
+++ b/src/Orienta/Classes/PropertyList.php
@@ -72,9 +72,8 @@ class PropertyList implements MapInterface
      */
     protected function instantiateProperty(array $config)
     {
-        $property = new Property();
+        $property = Property::fromConfig($config);
         $property->setClass($this->class);
-        $property->setData($config);
 
         return $property;
     }

--- a/src/Orienta/Classes/PropertyTrait.php
+++ b/src/Orienta/Classes/PropertyTrait.php
@@ -2,21 +2,62 @@
 
 namespace Orienta\Classes;
 
-/**
- * @property string $name The name of the property.
- * @property int $type The property type.
- * @property bool $mandatory true if the property is mandatory.
- * @property bool $readonly true if the property is read only.
- * @property bool $notNull true if the property cannot contain null values.
- * @property int|null $min The minimum value, if any.
- * @property int|null $max The maximum value, if any.
- * @property string $regexp The regular expression for this property.
- * @property array $customFields The custom fields for the property.
- *
- * @package Orienta\Classes
- */
 trait PropertyTrait
 {
+    /**
+     * @var string The name of the property.
+     */
+    public $name;
+
+    /**
+     * @var int The property type.
+     */
+    public $type;
+
+    /**
+     * @var bool Whether the property is mandatory.
+     */
+    public $mandatory;
+
+    /**
+     * @var bool Whether the property is read only.
+     */
+    public $readonly;
+
+    /**
+     * @var bool Whether the property cannot contain null values.
+     */
+    public $notNull;
+
+    /**
+     * @var int The minimum property value.
+     */
+    public $min;
+
+    /**
+     * @var int The maximum property value.
+     */
+    public $max;
+
+    /**
+     * @var string The regular expression that the property value should match.
+     */
+    public $regexp;
+
+    /**
+     * @var string The collation for this property.
+     */
+    public $collate;
+
+    /**
+     * @var string The linked class for this property.
+     */
+    public $linkedClass;
+
+    /**
+     * @var array The custom fields for the property.
+     */
+    public $customFields = [];
 
     /**
      * @var ClassInterface The class this property belongs to.
@@ -48,79 +89,6 @@ trait PropertyTrait
     public function getClass()
     {
         return $this->class;
-    }
-
-    /**
-     * Sets the Data
-     *
-     * @param array $data
-     *
-     * @return $this the current object
-     */
-    public function setData($data)
-    {
-        $this->data = $data;
-        return $this;
-    }
-
-    /**
-     * Gets the Data
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
-    }
-
-    /**
-     * Get an attribute with the given name.
-     *
-     * @param string $name The name of the attribute to get.
-     *
-     * @return mixed The value of the attribute.
-     * @throws \OutOfBoundsException
-     */
-    public function __get($name)
-    {
-        if (array_key_exists($name, $this->data)) {
-            return $this->data[$name];
-        }
-        else {
-            throw new \OutOfBoundsException(get_called_class().' does not have a property called "'.$name.'"');
-        }
-    }
-
-    /**
-     * Set an attribute with the given name.
-     *
-     * @param string $name The attribute name.
-     * @param mixed $value The attribute value.
-     */
-    public function __set($name, $value)
-    {
-        $this->data[$name] = $value;
-    }
-
-    /**
-     * Determine whether the attribute with the given name exists.
-     *
-     * @param string $name The name of the attribute.
-     *
-     * @return bool true if the attribute exists
-     */
-    public function __isset($name)
-    {
-        return isset($this->data[$name]);
-    }
-
-    /**
-     * Unset the attribute with the given name.
-     *
-     * @param string $name The name of the attribute to unset.
-     */
-    public function __unset($name)
-    {
-        unset($this->data[$name]);
     }
 
 }

--- a/src/Orienta/Validation/ErrorMessage.php
+++ b/src/Orienta/Validation/ErrorMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orienta\Validation;
+
+class ErrorMessage
+{
+    const __default = "The value is invalid.";
+
+    const MANDATORY = "{property} is mandatory.";
+    const NOT_NULL = "{property} cannot be null.";
+    const READ_ONLY = "{property} is read-only.";
+    const MIN_VALUE = "{property} must be at least {min}.";
+    const MAX_VALUE = "{property} must be at most {max}.";
+    const BAD_PATTERN = "{property} does not match the required pattern.";
+    const BAD_TYPE = "{property} must be a {expected}, got {given}.";
+}

--- a/src/Orienta/Validation/ValidatorInterface.php
+++ b/src/Orienta/Validation/ValidatorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orienta\Validation;
+
+interface ValidatorInterface
+{
+    /**
+     * Validate the given value.
+     *
+     * @param mixed $value The value to validate.
+     *
+     * @return array An array containing a boolean which is true if the value is valid,
+     *                followed by an array of validation errors, if any.
+     */
+    public function validate($value);
+}

--- a/tests/Orienta/Classes/ClassTest.php
+++ b/tests/Orienta/Classes/ClassTest.php
@@ -24,6 +24,16 @@ class ClassTest extends DbTestCase
         $this->assertInstanceOf('Orienta\Classes\Property', $this->class->getProperties()->name);
     }
 
+    public function testValidate()
+    {
+        list($valid, $errors) = $this->class->validate([
+            'name' => 'Charles',
+        ]);
+
+        $this->assertFalse($valid);
+        $this->assertGreaterThanOrEqual(2, count($errors));
+    }
+
     protected function setUp()
     {
         parent::setUp();

--- a/tests/Orienta/Classes/PropertyTest.php
+++ b/tests/Orienta/Classes/PropertyTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Orienta\Classes;
+
+use Orienta\DbTestCase;
+
+class PropertyTest extends DbTestCase
+{
+    public $class;
+
+    public function testValidateMandatory()
+    {
+        $property = new Property($this->class, [
+            'name' => 'myprop',
+            'mandatory' => true,
+        ]);
+
+        list($isValid, list($error)) = $property->validate(null);
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop is mandatory.', $error);
+
+        list($isValid, list($error)) = $property->validate('');
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop is mandatory.', $error);
+
+        list($isValid, $errors) = $property->validate('hello world');
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+    }
+
+    public function testValidateNotNull()
+    {
+        $property = new Property($this->class, [
+            'name' => 'myprop',
+            'notNull' => true,
+        ]);
+
+        list($isValid, list($error)) = $property->validate(null);
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop cannot be null.', $error);
+
+        list($isValid, $errors) = $property->validate('hello world');
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+    }
+
+    public function testValidatePattern()
+    {
+        $property = new Property($this->class, [
+            'name' => 'myprop',
+            'regexp' => '[M|F]'
+        ]);
+
+        list($isValid, list($error)) = $property->validate('G');
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop does not match the required pattern.', $error);
+
+        list($isValid, $errors) = $property->validate('M');
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate('F');
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate(null);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+    }
+
+    public function testMinNumber()
+    {
+        $property = new Property($this->class, [
+            'name' => 'myprop',
+            'min' => 3
+        ]);
+
+        list($isValid, list($error)) = $property->validate(1);
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop must be at least 3.', $error);
+
+        list($isValid, $errors) = $property->validate(3);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate(500);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate(null);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+    }
+
+
+    public function testMaxNumber()
+    {
+        $property = new Property($this->class, [
+            'name' => 'myprop',
+            'max' => 3
+        ]);
+
+        list($isValid, list($error)) = $property->validate(100);
+        $this->assertFalse($isValid);
+        $this->assertEquals('myprop must be at most 3.', $error);
+
+        list($isValid, $errors) = $property->validate(3);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate(-123);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+
+        list($isValid, $errors) = $property->validate(null);
+        $this->assertTrue($isValid);
+        $this->assertEquals([], $errors);
+    }
+
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->class = $this->db->getClass('OUser');
+    }
+
+
+}


### PR DESCRIPTION
Adds a `validate()` method to classes and properties which can validate values according to their schemas in OrientDB.

Todo
- [ ] validate readonly properties
- [ ] validate types
- [x] test with document instances
